### PR TITLE
Fix signature verification error

### DIFF
--- a/03_Build_K8S/scripts/install_kubeadm.sh
+++ b/03_Build_K8S/scripts/install_kubeadm.sh
@@ -3,10 +3,10 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl net-tools
 
 # Download the Google Cloud public signing key:
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
 # Add the Kubernetes apt repository:
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 # Update apt package index, install kubelet, kubeadm and kubectl, and pin their version:
 sudo apt-get update


### PR DESCRIPTION
Run setup_k8s_cluster.ps1 failed. Below is error snippet
`kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05`

[Same issue](https://github.com/kubernetes/release/issues/2862)

[Setup Instructions changed](https://kubernetes.io/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)